### PR TITLE
Change request ID from 8 bit to 32 bit

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -6,11 +6,12 @@ package gosnmp
 
 import (
 	"fmt"
-	l "github.com/alouca/gologger"
 	"math/rand"
 	"net"
 	"strings"
 	"time"
+
+	l "github.com/alouca/gologger"
 )
 
 // GoSNMP represents the GoSNMP poller structure
@@ -183,7 +184,7 @@ func (x *GoSNMP) sendPacket(packet *SnmpPacket) (*SnmpPacket, error) {
 	x.conn.SetDeadline(deadline.Add(x.Timeout))
 
 	// Create random Request-ID
-	packet.RequestID = uint8(rand.Uint32())
+	packet.RequestID = rand.Uint32()
 
 	// Marshal it
 	fBuf, err := packet.marshal()


### PR DESCRIPTION
Currently the request ID is using an 8 bit int. It is possible for the
request ID to be 32 bit. If we were to use 32 bit it would greatly
reduce the risk of sending duplicate request IDs.

When polling a Cisco Nexus devcie via BulkWalk, if a duplicate request
ID is sent then the device sends the response for the previous request.